### PR TITLE
CLOSES #1: Update source image to 1.7.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 - Update memcached package to `memcached-1.4.4-5.el6`.
 - Adds a change log (`CHANGELOG.md`).
 - Adds support for semantic version numbered tags.
+- Adds minor code style changes to the Makefile for readability.
 
 ### 1.0.0 - 2016-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 
 ### 1.0.1 - Unreleased
 
-- Add source from [jdeathe/centos-ssh:1.7.6](https://github.com/jdeathe/centos-ssh/releases/tag/1.7.6)
-- Update memcached package to `memcached-1.4.4-5.el6`.
+- Adds source from [jdeathe/centos-ssh:1.7.6](https://github.com/jdeathe/centos-ssh/releases/tag/1.7.6)
+- Updates memcached package to `memcached-1.4.4-5.el6`.
 - Adds a change log (`CHANGELOG.md`).
 - Adds support for semantic version numbered tags.
 - Adds minor code style changes to the Makefile for readability.
 - Adds support for running `shpec` functional tests with `make test`.
+- Adds correct spelling of Memcached in log file path: `/var/log/memcached.log`.
 
 ### 1.0.0 - 2016-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 - Adds a change log (`CHANGELOG.md`).
 - Adds support for semantic version numbered tags.
 - Adds minor code style changes to the Makefile for readability.
+- Adds support for running `shpec` functional tests with `make test`.
 
 ### 1.0.0 - 2016-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+## centos-6
+
+Summary of release changes for Version 1.
+
+CentOS-6 6.8 x86_64 - Memcached 1.4.
+
+### 1.0.1 - Unreleased
+
+- Adds a change log (`CHANGELOG.md`).
+
+### 1.0.0 - 2016-11-23
+
+- Initial release based on Memcached version 1.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 
 ### 1.0.1 - Unreleased
 
+- Add source from [jdeathe/centos-ssh:1.7.6](https://github.com/jdeathe/centos-ssh/releases/tag/1.7.6)
 - Update memcached package to `memcached-1.4.4-5.el6`.
 - Adds a change log (`CHANGELOG.md`).
 - Adds support for semantic version numbered tags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 
 ### 1.0.1 - Unreleased
 
+- Update memcached package to `memcached-1.4.4-5.el6`.
 - Adds a change log (`CHANGELOG.md`).
+- Adds support for semantic version numbered tags.
 
 ### 1.0.0 - 2016-11-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.7.3
+FROM jdeathe/centos-ssh:1.7.6
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,23 +55,23 @@ LABEL \
 --rm \
 --privileged \
 --volume /:/media/root \
-jdeathe/centos-ssh-memcached:centos-6-${RELEASE_VERSION} \
+jdeathe/centos-ssh-memcached:${RELEASE_VERSION} \
 /usr/sbin/scmi install \
 --chroot=/media/root \
 --name=\${NAME} \
---tag=centos-6-${RELEASE_VERSION}" \
+--tag=${RELEASE_VERSION}" \
 	uninstall="docker run \
 --rm \
 --privileged \
 --volume /:/media/root \
-jdeathe/centos-ssh-memcached:centos-6-${RELEASE_VERSION} \
+jdeathe/centos-ssh-memcached:${RELEASE_VERSION} \
 /usr/sbin/scmi uninstall \
 --chroot=/media/root \
 --name=\${NAME} \
---tag=centos-6-${RELEASE_VERSION}" \
+--tag=${RELEASE_VERSION}" \
 	org.deathe.name="centos-ssh-memcached" \
 	org.deathe.version="${RELEASE_VERSION}" \
-	org.deathe.release="jdeathe/centos-ssh-memcached:centos-6-${RELEASE_VERSION}" \
+	org.deathe.release="jdeathe/centos-ssh-memcached:${RELEASE_VERSION}" \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-memcached" \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ Targets:
   start                     Start the container in the created state.
   stop                      Stop the container when in a running state.
   terminate                 Unpause, stop and remove the container.
+  test                      Run all test cases.
   unpause                   Unpause the container when in a paused state.
 
 Variables:
@@ -114,6 +115,11 @@ xz := $(shell \
 	command -v xz \
 )
 
+# Testing prerequisites
+shpec := $(shell \
+	command -v shpec \
+)
+
 # Used to test docker host is accessible
 get-docker-info := $(shell \
 	$(docker) info \
@@ -131,6 +137,7 @@ get-docker-info := $(shell \
 	_require-docker-image-tag \
 	_require-docker-release-tag \
 	_require-package-path \
+	_test-prerequisites \
 	_usage \
 	all \
 	build \
@@ -155,6 +162,7 @@ get-docker-info := $(shell \
 	start \
 	stop \
 	terminate \
+	test \
 	unpause
 
 _prerequisites:
@@ -244,6 +252,11 @@ _require-package-path:
 		echo "$(PREFIX_STEP_NEGATIVE)Undefined DIST_PATH"; \
 		exit 1; \
 	fi
+
+_test-prerequisites:
+ifeq ($(shpec),)
+	$(error "Please install shpec.")
+endif
 
 _usage:
 	@: $(info $(USAGE))
@@ -485,6 +498,13 @@ terminate: _prerequisites
 			exit 1; \
 		fi; \
 	fi
+
+test: _test-prerequisites
+	@ if [[ -z $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); fi;) ]]; then \
+		$(MAKE) build; \
+	fi;
+	@ echo "$(PREFIX_STEP)Functional test";
+	@ SHPEC_ROOT=$(SHPEC_ROOT) $(shpec);
 
 unpause: _prerequisites _require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP)Unpausing container"

--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,10 @@ PREFIX_SUB_STEP_POSITIVE := $(shell \
 
 # Package prerequisites
 docker := $(shell \
-	type -p docker \
+	command -v docker \
 )
 xz := $(shell \
-	type -p xz \
+	command -v xz \
 )
 
 # Used to test docker host is accessible
@@ -172,78 +172,78 @@ endif
 
 _require-docker-container:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
-			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+		echo "$(PREFIX_SUB_STEP)Try removing it with: make rm"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not-status-paused:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
-			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+		echo "$(PREFIX_SUB_STEP)Try unpausing it with: make unpause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-created:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be created."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-exited:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
-			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+		echo "$(PREFIX_SUB_STEP)Try stopping it with: make stop"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-paused:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
-			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+		echo "$(PREFIX_SUB_STEP)Try pausing it with: make pause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-running:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
-			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be running."; \
+		echo "$(PREFIX_SUB_STEP)Try starting it with: make start"; \
+		exit 1; \
+	fi
 
 _require-docker-image-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		exit 1; \
+	fi
 
 _require-docker-release-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_SUB_STEP)A release tag is required for this operation."; \
+		exit 1; \
+	fi
 
 _require-package-path:
 	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP) Creating package directory"; \
-			mkdir -p $(DIST_PATH); \
-		fi; \
-		if [[ ! $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
-			exit 1; \
-		elif [[ -z $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP)Creating package directory"; \
+		mkdir -p $(DIST_PATH); \
+	fi; \
+	if [[ ! $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Failed to make package path: $(DIST_PATH)"; \
+		exit 1; \
+	elif [[ -z $(DIST_PATH) ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Undefined DIST_PATH"; \
+		exit 1; \
+	fi
 
 _usage:
 	@: $(info $(USAGE))
@@ -252,81 +252,81 @@ all: _prerequisites | build images install start ps
 
 # build NO_CACHE=[{false,true}]
 build: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
+	@ echo "$(PREFIX_STEP)Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 	@ if [[ $(NO_CACHE) == true ]]; then \
-			echo "$(PREFIX_SUB_STEP) Skipping cache"; \
-		fi
+		echo "$(PREFIX_SUB_STEP)Skipping cache"; \
+	fi
 	@ $(docker) build \
-			--no-cache=$(NO_CACHE) \
-			-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
-			.; \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Build complete"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Build error"; \
-			exit 1; \
-		fi
+		--no-cache=$(NO_CACHE) \
+		-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
+		.; \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Build complete"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Build error"; \
+		exit 1; \
+	fi
 
 clean: _prerequisites | terminate rmi
 
 create: _prerequisites _require-docker-container-not
-	@ echo "$(PREFIX_STEP) Creating container"
+	@ echo "$(PREFIX_STEP)Creating container"
 	@ set -x; \
-		$(docker) create \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) create \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container created"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container creation failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container created"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container creation failed"; \
+		exit 1; \
+	fi
 
 dist: _prerequisites _require-docker-release-tag _require-package-path | pull
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Saving package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
+		echo "$(PREFIX_STEP)Saving package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Package already exists"; \
+	else \
+		echo "$(PREFIX_STEP)Saving package"; \
+		$(docker) save \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
+			$(xz) -9 > \
+				$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
+		if [[ $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package saved"; \
 		else \
-			echo "$(PREFIX_STEP) Saving package"; \
-			$(docker) save \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
-				$(xz) -9 > \
-					$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
-				if [[ $${?} -eq 0 ]]; then \
-					echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
-				else \
-					echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
-					exit 1; \
-				fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package save error"; \
+			exit 1; \
+		fi; \
+	fi
 
 distclean: _prerequisites _require-docker-release-tag _require-package-path | clean
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Deleting package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			find $($@_dist_path) \
-				-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
-				-delete; \
-			if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
-				exit 1; \
-			fi; \
+		echo "$(PREFIX_STEP)Deleting package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		find $($@_dist_path) \
+			-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
+			-delete; \
+		if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package cleanup complete"; \
 		else \
-			echo "$(PREFIX_STEP) Package cleanup skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package cleanup failed"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP)Package cleanup skipped"; \
+	fi
 
 exec: _prerequisites
 	@ $(docker) exec -it $(DOCKER_NAME) $(filter-out $@, $(MAKECMDGOALS))
@@ -334,7 +334,7 @@ exec: _prerequisites
 
 images: _prerequisites
 	@ $(docker) images \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
 
 help: _usage
 
@@ -351,142 +351,142 @@ load: _prerequisites _require-docker-release-tag _require-package-path
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
-	@ echo "$(PREFIX_STEP) Loading image from package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
-			exit 1; \
-		else \
-			$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
-				$(docker) load; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
-		fi
+	@ echo "$(PREFIX_STEP)Loading image from package"; \
+	echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+	if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Package not found"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
+		exit 1; \
+	else \
+		$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
+			$(docker) load; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image loaded"; \
+	fi
 
 pause: _prerequisites _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Pausing container"
+	@ echo "$(PREFIX_STEP)Pausing container"
 	@ $(docker) pause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container paused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container paused"
 
 pull: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Pulling image from registry"
+	@ echo "$(PREFIX_STEP)Pulling image from registry"
 	@ $(docker) pull \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image pulled"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error pulling image"; \
-			exit 1; \
-		fi
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image pulled"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Error pulling image"; \
+		exit 1; \
+	fi
 
 ps: _prerequisites _require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
 
 restart: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Restarting container"
+	@ echo "$(PREFIX_STEP)Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container restarted"
 
 rm: _prerequisites _require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container removal skipped"; \
+		echo "$(PREFIX_STEP)Container removal skipped"; \
+	else \
+		echo "$(PREFIX_STEP)Removing container"; \
+		$(docker) rm -f $(DOCKER_NAME); \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container removed"; \
 		else \
-		  echo "$(PREFIX_STEP) Removing container"; \
-			$(docker) rm -f $(DOCKER_NAME); \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container removal failed"; \
+			exit 1; \
+		fi; \
+	fi
 
 rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
-	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
-			echo "$(PREFIX_STEP) Untagging image"; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
-			$(docker) rmi \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
-			if [[ $${?} -eq 0 ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Image untagged"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error untagging image"; \
-				exit 1; \
-			fi; \
+	@ if [[ -n $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) ]]; then \
+		echo "$(PREFIX_STEP)Untagging image"; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
+		$(docker) rmi \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
+		if [[ $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Image untagged"; \
 		else \
-			echo "$(PREFIX_STEP) Untagging image skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error untagging image"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP)Untagging image skipped"; \
+	fi
 
 run: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Running container"
+	@ echo "$(PREFIX_STEP)Running container"
 	@ set -x; \
-		$(docker) run \
-			--detach \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) run \
+		--detach \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container running"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container run failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container running"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container run failed"; \
+		exit 1; \
+	fi
 
 start: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Starting container"
+	@ echo "$(PREFIX_STEP)Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
-			&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) start $(DOCKER_NAME) 1> /dev/null; \
-		fi
+		&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+		$(docker) start $(DOCKER_NAME) 1> /dev/null; \
+	fi
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container started"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container start failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container started"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container start failed"; \
+		exit 1; \
+	fi
 
 stop: _prerequisites _require-docker-container-not-status-paused _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Stopping container"
+	@ echo "$(PREFIX_STEP)Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
-				exit 1; \
-			fi; \
-		fi
+		$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container stopped"; \
+		else \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error stopping container"; \
+			exit 1; \
+		fi; \
+	fi
 
 terminate: _prerequisites
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container termination skipped"; \
+		echo "$(PREFIX_STEP)Container termination skipped"; \
+	else \
+		echo "$(PREFIX_STEP)Terminating container"; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Unpausing container"; \
+			$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Stopping container"; \
+			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Removing container"; \
+			$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container terminated"; \
 		else \
-			echo "$(PREFIX_STEP) Terminating container"; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Unpausing container"; \
-				$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Stopping container"; \
-				$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Removing container"; \
-				$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container termination failed"; \
+			exit 1; \
+		fi; \
+	fi
 
 unpause: _prerequisites _require-docker-container-status-paused
-	@ echo "$(PREFIX_STEP) Unpausing container"
+	@ echo "$(PREFIX_STEP)Unpausing container"
 	@ $(docker) unpause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container unpaused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container unpaused"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Docker Image including CentOS-6 6.8 x86_64 and Memcached 1.4.
 
 ## Overview & links
 
-- centos-6 [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-6/Dockerfile)
+The latest CentOS-6 based release can be pulled from the `centos-6` Docker tag. It is recommended to select a specific release tag - the convention is `centos-6-1.0.0` or `1.0.0` for the [1.0.0](https://github.com/jdeathe/centos-ssh-memcached/tree/1.0.0) release tag.
 
-#### centos-6
+### Tags and respective `Dockerfile` links
 
-The latest CentOS-6 based release can be pulled from the `centos-6` Docker tag. For a specific release tag the convention is `centos-6-1.0.0` for the [1.0.0](https://github.com/jdeathe/centos-ssh-memcached/tree/1.0.0) release tag.
+- `centos-6`, `centos-6-1.0.0`, `1.0.0` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-6/Dockerfile)
 
 Included in the build are the [SCL](https://www.softwarecollections.org/), [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout).
 
@@ -47,7 +47,9 @@ $ docker logs memcached.pool-1.1.1
 To verify the Memcached service status:
 
 ```
-$ docker exec -it memcached.pool-1.1.1 memcached-tool localhost stats
+$ docker exec -it \
+  memcached.pool-1.1.1 \
+  memcached-tool localhost stats
 ```
 
 ## Instructions

--- a/environment.mk
+++ b/environment.mk
@@ -5,8 +5,8 @@ DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-memcached
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$
-DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
+DOCKER_IMAGE_TAG_PATTERN := ^(latest|centos-6|((1|centos-6-1)\.[0-9]+\.[0-9]+))$
+DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^(1|centos-6-1)\.[0-9]+\.[0-9]+$
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/etc/services-config/supervisor/supervisord.d/memcached-wrapper.conf
+++ b/etc/services-config/supervisor/supervisord.d/memcached-wrapper.conf
@@ -4,5 +4,5 @@ command = /usr/sbin/memcached-wrapper
 startsecs = 0
 autorestart = true
 redirect_stderr = true
-stdout_logfile = /var/log/memecached.log
+stdout_logfile = /var/log/memcached.log
 stdout_events_enabled = true

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -5,8 +5,8 @@ DOCKER_USER=jdeathe
 DOCKER_IMAGE_NAME=centos-ssh-memcached
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$'
-DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|7-2).[0-9]+.[0-9]+$'
+DOCKER_IMAGE_TAG_PATTERN='^(latest|centos-6|((1|centos-6-1)\.[0-9]+\.[0-9]+))$'
+DOCKER_IMAGE_RELEASE_TAG_PATTERN='^(1|centos-6-1)\.[0-9]+\.[0-9]+$'
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/test/shpec/makefile.sh
+++ b/test/shpec/makefile.sh
@@ -1,0 +1,114 @@
+describe "Makefile"
+	readonly DOCKER_NAME="makefile_test"
+
+	it "builds the image"
+		local status_make_build
+
+		make build &> /dev/null
+		status_make_build=${?}
+
+		assert equal ${status_make_build} 0
+	end
+
+	it "creates the container"
+		local status_make_install
+
+		make install &> /dev/null
+		status_make_install=${?}
+
+		assert equal ${status_make_install} 0
+	end
+
+	it "starts the container"
+		local status_make_start
+
+		make start &> /dev/null
+		status_make_start=${?}
+
+		assert equal ${status_make_start} 0
+	end
+
+	it "pauses the container"
+		local status_make_pause
+
+		make pause &> /dev/null
+		status_make_pause=${?}
+
+		assert equal ${status_make_pause} 0
+	end
+
+	it "unpauses the container"
+		local status_make_unpause
+
+		make unpause &> /dev/null
+		status_make_unpause=${?}
+
+		assert equal ${status_make_unpause} 0
+	end
+
+	it "restarts the container"
+		local status_make_restart
+
+		make restart &> /dev/null
+		status_make_restart=${?}
+
+		assert equal ${status_make_restart} 0
+	end
+
+	it "outputs the container logs"
+		local status_make_logs
+		local content_make_logs
+
+		content_make_logs=$(
+			make logs
+		)
+		status_make_logs=${?}
+
+		assert equal ${status_make_logs} 0
+	end
+
+	it "terminates the container"
+		local status_make_terminate
+
+		make terminate &> /dev/null
+		status_make_terminate=${?}
+
+		assert equal ${status_make_terminate} 0
+	end
+
+	it "runs the container"
+		local status_make_run
+
+		make run &> /dev/null
+		status_make_run=${?}
+
+		assert equal ${status_make_run} 0
+	end
+
+	it "stops the container"
+		local status_make_stop
+
+		make stop &> /dev/null
+		status_make_stop=${?}
+
+		assert equal ${status_make_stop} 0
+	end
+
+	it "deletes the container"
+		local status_make_rm
+	
+		make rm &> /dev/null
+		status_make_rm=${?}
+	
+		assert equal ${status_make_rm} 0
+	end
+
+	it "untags the image"
+		local status_make_clean
+	
+		make rmi &> /dev/null
+		status_make_clean=${?}
+	
+		assert equal ${status_make_clean} 0
+	end
+end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -60,6 +60,7 @@ function __terminate_container ()
 function test_basic_operations ()
 {
 	local container_port_11211=""
+	local maxbytes_value=""
 
 	trap "__terminate_container memcached.pool-1.1.1 &> /dev/null; \
 		__destroy; \
@@ -110,6 +111,21 @@ function test_basic_operations ()
 			assert equal \
 				"${?}" \
 				0
+		end
+
+		it "Defaults to a maxbytes setting of 64M."
+			maxbytes_value="$(
+				expect test/telnet-memcached.exp \
+					127.0.0.1 \
+					${container_port_11211} \
+					"stats settings" \
+				| grep -E '^STAT maxbytes [0-9]+' \
+				| awk '{ print $3; }'
+			)"
+
+			assert __shpec_matcher_egrep \
+				"${maxbytes_value}" \
+				67108864
 		end
 
 		__terminate_container \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -145,6 +145,22 @@ function test_basic_operations ()
 				1024
 		end
 
+		it "Defaults to TCP only (i.e udpport setting of 0)."
+			udpport_value="$(
+				expect test/telnet-memcached.exp \
+					127.0.0.1 \
+					${container_port_11211} \
+					"stats settings" \
+				| grep -E '^STAT udpport [0-9]+' \
+				| awk '{ print $3; }' \
+				| tr -d '\r'
+			)"
+
+			assert equal \
+				"${udpport_value}" \
+				0
+		end
+
 		__terminate_container \
 			memcached.pool-1.1.1 \
 		&> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,0 +1,128 @@
+readonly BOOTSTRAP_BACKOFF_TIME=3
+readonly TEST_DIRECTORY="test"
+
+# These should ideally be a static value but hosts might be using this port so 
+# need to allow for alternatives.
+DOCKER_PORT_MAP_TCP_22="${DOCKER_PORT_MAP_TCP_22:-NULL}"
+DOCKER_PORT_MAP_TCP_11211="${DOCKER_PORT_MAP_TCP_11211:-11211}"
+
+function __destroy ()
+{
+	:
+}
+
+function __setup ()
+{
+	:
+}
+
+# Custom shpec matcher
+# Match a string with an Extended Regular Expression pattern.
+function __shpec_matcher_egrep ()
+{
+	local pattern="${2:-}"
+	local string="${1:-}"
+
+	printf -- \
+		'%s' \
+		"${string}" \
+	| grep -qE -- \
+		"${pattern}" \
+		-
+
+	assert equal \
+		"${?}" \
+		0
+}
+
+function __terminate_container ()
+{
+	local container="${1}"
+
+	if docker ps -aq \
+		--filter "name=${container}" \
+		--filter "status=paused" &> /dev/null; then
+		docker unpause ${container} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${container}" \
+		--filter "status=running" &> /dev/null; then
+		docker stop ${container} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${container}" &> /dev/null; then
+		docker rm -vf ${container} &> /dev/null
+	fi
+}
+
+function test_basic_operations ()
+{
+	local container_port_11211=""
+
+	trap "__terminate_container memcached.pool-1.1.1 &> /dev/null; \
+		__destroy; \
+		exit 1" \
+		INT TERM EXIT
+
+	describe "Basic Memcached operations"
+		__terminate_container \
+			memcached.pool-1.1.1 \
+		&> /dev/null
+
+		it "Runs a Memecached container named memcached.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_11211}."
+			docker run \
+				--detach \
+				--name memcached.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_11211}:11211 \
+				jdeathe/centos-ssh-memcached:latest \
+			&> /dev/null
+
+			container_port_11211="$(
+				docker port \
+					memcached.pool-1.1.1 \
+					11211/tcp
+			)"
+			container_port_11211=${container_port_11211##*:}
+
+			if [[ ${DOCKER_PORT_MAP_TCP_11211} == 0 ]] \
+				|| [[ -z ${DOCKER_PORT_MAP_TCP_11211} ]]; then
+				assert gt \
+					"${container_port_11211}" \
+					"30000"
+			else
+				assert equal \
+					"${container_port_11211}" \
+					"${DOCKER_PORT_MAP_TCP_11211}"
+			fi
+		end
+
+		__terminate_container \
+			memcached.pool-1.1.1 \
+		&> /dev/null
+	end
+
+	trap - \
+		INT TERM EXIT
+}
+
+function test_custom_configuration ()
+{
+	:
+}
+
+if [[ ! -d ${TEST_DIRECTORY} ]]; then
+	printf -- \
+		"ERROR: Please run from the project root.\n" \
+		>&2
+	exit 1
+fi
+
+describe "jdeathe/centos-ssh-memcached:latest"
+	__destroy
+	__setup
+	test_basic_operations
+	test_custom_configuration
+	__destroy
+end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -120,12 +120,29 @@ function test_basic_operations ()
 					${container_port_11211} \
 					"stats settings" \
 				| grep -E '^STAT maxbytes [0-9]+' \
-				| awk '{ print $3; }'
+				| awk '{ print $3; }' \
+				| tr -d '\r'
 			)"
 
-			assert __shpec_matcher_egrep \
+			assert equal \
 				"${maxbytes_value}" \
 				67108864
+		end
+
+		it "Defaults to a maxconns setting of 1024."
+			maxconns_value="$(
+				expect test/telnet-memcached.exp \
+					127.0.0.1 \
+					${container_port_11211} \
+					"stats settings" \
+				| grep -E '^STAT maxconns [0-9]+' \
+				| awk '{ print $3; }' \
+				| tr -d '\r'
+			)"
+
+			assert equal \
+				"${maxconns_value}" \
+				1024
 		end
 
 		__terminate_container \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -71,7 +71,7 @@ function test_basic_operations ()
 			memcached.pool-1.1.1 \
 		&> /dev/null
 
-		it "Runs a Memecached container named memcached.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_11211}."
+		it "Runs a Memcached container named memcached.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_11211}."
 			docker run \
 				--detach \
 				--name memcached.pool-1.1.1 \
@@ -96,6 +96,20 @@ function test_basic_operations ()
 					"${container_port_11211}" \
 					"${DOCKER_PORT_MAP_TCP_11211}"
 			fi
+		end
+
+		sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+		it "Responds to the Memcached stats command."
+			expect test/telnet-memcached.exp \
+				127.0.0.1 \
+				${container_port_11211} \
+				"stats" \
+			| grep -qE '^STAT uptime [0-9]+'
+
+			assert equal \
+				"${?}" \
+				0
 		end
 
 		__terminate_container \

--- a/test/telnet-memcached.exp
+++ b/test/telnet-memcached.exp
@@ -1,0 +1,57 @@
+#!/usr/bin/env expect -f
+
+set env(HOME) /usr/local/bin
+set env(SHELL) /bin/bash
+set env(TERM) xterm
+set timeout 3
+
+# Destination IP address
+set HOST [lindex ${argv} 0]
+
+# Destination Port
+set PORT [lindex ${argv} 1]
+
+# Memcached commands
+set COMMAND [lindex ${argv} 2]
+
+# Usage instructions if no arguments supplied.
+if { ${argc} < 1 } {
+	send_user "Usage: ${argv0} <host> <port> \[command\]\n"
+	send_user "e.g.   ${argv0} 127.0.0.1 11211 \"stats settings\"\n"
+	send_user "       ${argv0} 127.0.0.1 11211 \"set key_name 0 60 10\"$'\\n'\"0123456789\"\n"
+	send_user "       ${argv0} 127.0.0.1 11211 \"get key_name\"\n\n"
+	exit 1
+}
+
+if {
+	[info exists PORT]
+	&& "${PORT}" == ""
+} {
+	set PORT "11211"
+}
+
+if {
+	[info exists COMMAND]
+	&& "${COMMAND}" == ""
+} {
+	set COMMAND "stats"
+}
+
+log_user 0
+spawn telnet ${HOST} ${PORT}
+expect {
+	default {
+		send_user "ERROR: Unable to connect to ${HOST} ${PORT}\n"
+		exit 1
+	}
+	"'^]'." {
+		log_user 1
+		send "${COMMAND}\n"
+		expect {
+			-re "(?:DELETED|END|ERROR|NOT_FOUND|STORED|VERSION \[0-9\]+\.\[0-9\]+\.\[0-9\]+)" {
+				send "quit\n"
+			}
+		}
+		expect eof
+	}
+}

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## Functional
+
+### Installation
+
+The functional test cases are written in [shpec](https://github.com/rylnd/shpec). 
+
+To run the tests install shpec with the installer.
+
+```
+$ bash -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
+```
+
+### Usage
+
+To manually run the test cases, from the project root:
+
+```
+$ SHPEC_ROOT=test/shpec shpec
+```

--- a/usr/sbin/memcached-wrapper
+++ b/usr/sbin/memcached-wrapper
@@ -14,7 +14,7 @@ DAEMON_OPTS="
 NICENESS=${MEMCACHED_NICENESS:-0}
 
 printf -- \
-	"Starting Memcached: \n%s\n" \
+	"Starting Memcached: %s" \
 	"${DAEMON_OPTS}"
 
 exec ${NICE} \


### PR DESCRIPTION
Resolves #1

- Adds source from [jdeathe/centos-ssh:1.7.6](https://github.com/jdeathe/centos-ssh/releases/tag/1.7.6)
- Adds a change log (`CHANGELOG.md`).
- Adds support for semantic version numbered tags.
- Adds minor code style changes to the Makefile for readability.
- Adds support for running `shpec` functional tests with `make test`.
- Adds correct spelling of Memcached in log file path: `/var/log/memcached.log`.