### PR TITLE
CLOSES #4: Replaces deprecated Dockerfile MAINTAINER with a LABEL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CentOS-6 6.8 x86_64 - Memcached 1.4.
 - Adds minor code style changes to the Makefile for readability.
 - Adds support for running `shpec` functional tests with `make test`.
 - Adds correct spelling of Memcached in log file path: `/var/log/memcached.log`.
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 
 ### 1.0.0 - 2016-11-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@
 # =============================================================================
 FROM jdeathe/centos-ssh:1.7.6
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 RUN rpm --rebuilddb \
 	&& yum -y install \
 			--setopt=tsflags=nodocs \
@@ -51,6 +49,7 @@ ENV MEMCACHED_CACHESIZE="64" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="1.0.0"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="docker run \
 --rm \
 --privileged \


### PR DESCRIPTION
Resolves #4: 

- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.