### PR TITLE
CLOSES #23: Updates upstream source to 1.8.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64 - Memcached 1.4.
 
+### 1.1.1 - Unreleased
+
+- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).
+
 ### 1.1.0 - 2017-08-08
 
 - Fixes issue with expect script failure when using `expect -f`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.1
+FROM jdeathe/centos-ssh:1.8.2
 
 RUN rpm --rebuilddb \
 	&& yum -y install \


### PR DESCRIPTION
Resolves #23 

- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).