### PR TITLE
CLOSES #27: Updates upstream source image to 1.8.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CentOS-6 6.9 x86_64 - Memcached 1.4.
 
 ### 1.1.2 - Unreleased
 
+- Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).
 - Adds a `.dockerignore` file.
 
 ### 1.1.1 - 2017-09-15

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.2
+FROM jdeathe/centos-ssh:1.8.3
 
 RUN rpm --rebuilddb \
 	&& yum -y install \


### PR DESCRIPTION
Resolves #27 

- Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).