### PR TITLE
CLOSES #39: Updates source image to 1.9.0 (CentOS-6 6.10).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 Summary of release changes for Version 1.
 
-CentOS-6 6.9 x86_64 - Memcached 1.4.
+CentOS-6 6.10 x86_64 - Memcached 1.4.
 
-### 1.1.4 - Unreleased
+### 1.2.0 - Unreleased
 
 - Adds details of the centos-7 (Version 2) branch to the README.
+- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
 
 ### 1.1.3 - 2018-05-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.4
+FROM jdeathe/centos-ssh:1.9.0
 
 RUN rpm --rebuilddb \
 	&& yum -y install \
@@ -79,7 +79,7 @@ jdeathe/centos-ssh-memcached:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-memcached" \
-	org.deathe.description="CentOS-6 6.9 x86_64 - Memcached 1.4."
+	org.deathe.description="CentOS-6 6.10 x86_64 - Memcached 1.4."
 
 HEALTHCHECK \
 	--interval=0.5s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.9 x86_64 - Memcached.
+CentOS-6 6.10 x86_64 - Memcached.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ centos-ssh-memcached
 
 Docker Image including:
 
-- CentOS-6 6.9 x86_64 and Memcached 1.4.
-- CentOS-7 7.4.1708 x86_64 and Memcached 1.4.
+- CentOS-6 6.10 x86_64 and Memcached 1.4.
+- CentOS-7 7.5.1804 x86_64 and Memcached 1.4.
 
 ## Overview & links
 


### PR DESCRIPTION
CLOSES #39 

- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).