### PR TITLE
CLOSES #40: Updates source image to 2.4.0 (CentOS-7 7.5.1804).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.4.1708 x86_64 - Memcached 1.4.
 
+### 2.1.0 - Unreleased
+
+- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
+
 ### 2.0.0 - 2018-05-12
 
 - Initial release based on Memcached version 1.4.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-7, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:2.3.2
+FROM jdeathe/centos-ssh:2.4.0
 
 RUN rpm --rebuilddb \
 	&& yum -y install \
@@ -79,7 +79,7 @@ jdeathe/centos-ssh-memcached:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-memcached" \
-	org.deathe.description="CentOS-7 7.4.1708 x86_64 - Memcached 1.4."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - Memcached 1.4."
 
 HEALTHCHECK \
 	--interval=0.5s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-7 7.4.1708 x86_64 - Memcached.
+CentOS-7 7.5.1804 x86_64 - Memcached.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ centos-ssh-memcached
 
 Docker Image including:
 
-- CentOS-6 6.9 x86_64 and Memcached 1.4.
-- CentOS-7 7.4.1708 x86_64 and Memcached 1.4.
+- CentOS-6 6.10 x86_64 and Memcached 1.4.
+- CentOS-7 7.5.1804 x86_64 and Memcached 1.4.
 
 ## Overview & links
 


### PR DESCRIPTION
CLOSES #40

- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).