### PR TITLE
CLOSES #45: Fixes typo in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64 - Memcached 1.4.
 
+### 2.1.1 - Unreleased
+
+- Fixes typo in test; using `--format` instead of `--filter`.
+
 ### 2.1.0 - 2018-08-16
 
 - Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -517,8 +517,8 @@ function test_custom_configuration ()
 
 		it "Can disable memcached-wrapper."
 			docker ps \
-				--format "name=memcached.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=memcached.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				memcached.pool-1.1.1 \


### PR DESCRIPTION
#45 

- Fixes typo in test; using `--format` instead of `--filter`.