### PR TITLE
CLOSES #48: Fixes typo in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Memcached 1.4.
 
+### 1.2.1 - Unreleased
+
+- Fixes typo in test; using `--format` instead of `--filter`.
+
 ### 1.2.0 - 2018-08-16
 
 - Adds details of the centos-7 (Version 2) branch to the README.

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -516,8 +516,8 @@ function test_custom_configuration ()
 
 		it "Can disable memcached-wrapper."
 			docker ps \
-				--format "name=memcached.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=memcached.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				memcached.pool-1.1.1 \


### PR DESCRIPTION
#48

- Fixes typo in test; using `--format` instead of `--filter`.