### PR TITLE
CLOSES #53: Updates source image to 2.4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-7 7.5.1804 x86_64 - Memcached 1.4.
 
 - Fixes typo in test; using `--format` instead of `--filter`.
 - Adds required `--sysctl` settings to docker run templates.
+- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
 
 ### 2.1.0 - 2018-08-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-7, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:2.4.0
+FROM jdeathe/centos-ssh:2.4.1
 
 RUN rpm --rebuilddb \
 	&& yum -y install \


### PR DESCRIPTION
CLOSES #53

- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
