### PR TITLE
CLOSES #54: Updates source image to 1.9.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.10 x86_64 - Memcached 1.4.
 
 - Fixes typo in test; using `--format` instead of `--filter`.
 - Adds required `--sysctl` settings to docker run templates.
+- Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).
 
 ### 1.2.0 - 2018-08-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # CentOS-6, Memcached 1.4.
 # =============================================================================
-FROM jdeathe/centos-ssh:1.9.0
+FROM jdeathe/centos-ssh:1.9.1
 
 RUN rpm --rebuilddb \
 	&& yum -y install \


### PR DESCRIPTION
CLOSES #54

- Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).