### PR TITLE
CLOSES #82: Adds improved logging output; startup time restored to 1s.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ CentOS-6 6.10 x86_64 - Memcached 1.4.
 - Adds improved memcached-wrapper script including optional Details output.
 - Adds validation on `MEMCACHED_CACHESIZE` and `MEMCACHED_MAXCONN` - fails back to default if not a positive non-zero integer.
 - Adds docker-compose configuration example.
+- Adds improved logging output.
 - Removes use of `/etc/services-config` paths.
 - Removes X-Fleet section from etcd register template unit-file.
 - Removes the unused group element from the default container name.
 - Removes the node element from the default container name.
 - Removes unused environment variables from Makefile and scmi configuration.
+- Removes container log file `/var/log/memcached.log`.
 
 ### 1.2.1 - 2018-11-16
 

--- a/environment.mk
+++ b/environment.mk
@@ -33,7 +33,7 @@ NO_CACHE ?= false
 DIST_PATH ?= ./dist
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME ?= 2
+STARTUP_TIME ?= 1
 
 # ------------------------------------------------------------------------------
 # Application container configuration

--- a/src/etc/supervisord.d/memcached-wrapper.conf
+++ b/src/etc/supervisord.d/memcached-wrapper.conf
@@ -2,8 +2,8 @@
 priority = 100
 command = /usr/sbin/memcached-wrapper --verbose
 autostart = %(ENV_MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER)s
-startsecs = 1
+startsecs = 0
 autorestart = true
 redirect_stderr = true
-stdout_logfile = /var/log/memcached.log
-stdout_events_enabled = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0

--- a/src/opt/scmi/environment.sh
+++ b/src/opt/scmi/environment.sh
@@ -27,7 +27,7 @@ NO_CACHE="${NO_CACHE:-false}"
 DIST_PATH="${DIST_PATH:-./dist}"
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME="${STARTUP_TIME:-2}"
+STARTUP_TIME="${STARTUP_TIME:-1}"
 
 # Docker --sysctl settings
 SYSCTL_NET_CORE_SOMAXCONN="${SYSCTL_NET_CORE_SOMAXCONN:-1024}"

--- a/src/opt/scmi/service-unit.sh
+++ b/src/opt/scmi/service-unit.sh
@@ -24,4 +24,4 @@ readonly SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS="
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
-SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-5}"
+SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-4}"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,4 +1,4 @@
-readonly STARTUP_TIME=2
+readonly STARTUP_TIME=1
 readonly TEST_DIRECTORY="test"
 
 # These should ideally be a static value but hosts might be using this port so 


### PR DESCRIPTION
CLOSES #82: Patches back #81.

- Adds improved logging output.
- Removes container log file `/var/log/memcached.log`.