### PR TITLE
CLOSES #87: Updates source image to 2.5.1.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.env
+.env.example
 .git
 .gitignore
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64 - Memcached 1.4.
 
+### 2.2.1 - Unreleased
+
+- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
+- Updates Dockerfile with combined ADD to reduce layer count in final image.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
+- Adds improvement to pull logic in systemd unit install template.
+- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
+- Adds improved `healtchcheck` and `memcached-wrapper` scripts.
+
 ### 2.2.0 - 2019-02-12
 
 - Updates source image to [2.5.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdeathe/centos-ssh:2.5.0
+FROM jdeathe/centos-ssh:2.5.1
 
 ARG RELEASE_VERSION="2.2.0"
 
@@ -20,15 +20,11 @@ RUN rpm --rebuilddb \
 # ------------------------------------------------------------------------------
 # Copy files into place
 # ------------------------------------------------------------------------------
-ADD src/etc \
-	/etc/
-ADD src/opt/scmi \
-	/opt/scmi/
-ADD src/usr \
-	/usr/
+ADD src /
 
 # ------------------------------------------------------------------------------
 # Provisioning
+# - Replace placeholders with values in systemd service unit template
 # - Set permissions
 # ------------------------------------------------------------------------------
 RUN sed -i \
@@ -49,7 +45,8 @@ ENV MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER="true" \
 	MEMCACHED_MAXCONN="1024" \
 	MEMCACHED_OPTIONS="-U 0" \
 	SSH_AUTOSTART_SSHD="false" \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP="false"
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	SSH_AUTOSTART_SUPERVISOR_STDOUT="false"
 
 # ------------------------------------------------------------------------------
 # Set image metadata

--- a/src/etc/systemd/system/centos-ssh-memcached.register@.service
+++ b/src/etc/systemd/system/centos-ssh-memcached.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -91,7 +92,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -104,7 +105,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -129,15 +130,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/11211 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/11211 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
       /usr/bin/etcdctl \
@@ -148,15 +149,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/udp/11211 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/udp/11211 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \

--- a/src/etc/systemd/system/centos-ssh-memcached@.service
+++ b/src/etc/systemd/system/centos-ssh-memcached@.service
@@ -26,7 +26,8 @@
 #     sudo systemctl enable -f {service-unit-instance-name}
 #
 # Start using:
-#     sudo systemctl [start|stop|restart|kill|status] {service-unit-instance-name}
+#     sudo systemctl [start|stop|restart|kill|status] \
+#       {service-unit-instance-name}
 #
 # Debugging:
 #     sudo systemctl status {service-unit-instance-name}
@@ -34,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -65,20 +67,12 @@ Environment="SYSCTL_NET_IPV4_ROUTE_FLUSH=1"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( \
-      if [[ -n $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ) ]]; \
-      then \
-        echo $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      else \
-        echo $(/usr/bin/docker images -q \
-          docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      fi; \
-    ) ]]; \
+  "if [[ -z \"$(/usr/bin/docker images -q \
+      ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]] \
+    && [[ -z \"$(/usr/bin/docker images -q \
+      docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]]; \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
@@ -140,7 +134,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_TCP_11211}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:11211/tcp' \
           $(\
@@ -173,7 +167,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_UDP_11211}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:11211/udp' \
           $(\

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -2,37 +2,40 @@
 
 set -e
 
-if ! ps axo command \
-	| grep -qE '^/usr/bin/python /usr/bin/supervisord'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"supervisord not running."
-	exit 1
-fi
-
-if [[ ${MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER} == true ]]
-then
+function main ()
+{
 	if ! ps axo command \
-		| grep -qE '^/usr/bin/memcached '
+		| grep -qE '^/usr/bin/python /usr/bin/supervisord'
 	then
 		>&2 printf -- \
 			'%s\n' \
-			"memcached not running."
+			"supervisord not running."
 		exit 1
 	fi
 
-	if ! memcached-tool \
-			127.0.0.1:11211 \
-			stats \
-		| grep -qP \
-			'[ ]+accepting_conns[ ]+1[^0-9]*$'
+	if [[ ${MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER} == true ]]
 	then
-		>&2 printf -- \
-			'%s\n' \
-			"memcached not accepting connections."
-		exit 1
-	fi
-fi
+		if ! ps axo command \
+			| grep -qE '^/usr/bin/memcached '
+		then
+			>&2 printf -- \
+				'%s\n' \
+				"memcached not running."
+			exit 1
+		fi
 
-exit 0
+		if ! memcached-tool \
+				127.0.0.1:11211 \
+				stats \
+			| grep -qP \
+				'[ ]+accepting_conns[ ]+1[^0-9]*$'
+		then
+			>&2 printf -- \
+				'%s\n' \
+				"memcached not accepting connections."
+			exit 1
+		fi
+	fi
+}
+
+main "${@}"

--- a/src/usr/sbin/memcached-wrapper
+++ b/src/usr/sbin/memcached-wrapper
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-readonly TIMER_START="$(
-	date +%s.%N
-)"
+set -e
 
 function __is_valid_memcached_cachesize ()
 {
@@ -92,24 +90,16 @@ function __get_options ()
 function main ()
 {
 	local -r bin="/usr/bin/memcached"
-	local -r memcached_cachesize="$(
-		__get_memcached_cachesize
-	)"
-	local -r memcached_maxconn="$(
-		__get_memcached_maxconn
-	)"
-	local -r memcached_options="$(
-		__get_memcached_options
-	)"
 	local -r nice="/bin/nice"
 	local -r niceness="0"
-	local -r options="$(
-		__get_options \
-			"${memcached_cachesize}" \
-			"${memcached_maxconn}" \
-			"${memcached_options}"
+	local -r timer_start="$(
+		date +%s.%N
 	)"
 
+	local memcached_cachesize
+	local memcached_maxconn
+	local memcached_options
+	local options
 	local timer_total
 	local verbose=false
 
@@ -126,12 +116,29 @@ function main ()
 
 	if [[ ${verbose} == true ]]
 	then
+		memcached_cachesize="$(
+			__get_memcached_cachesize
+		)"
+		memcached_maxconn="$(
+			__get_memcached_maxconn
+		)"
+		memcached_options="$(
+			__get_memcached_options
+		)"
+
+		options="$(
+			__get_options \
+				"${memcached_cachesize}" \
+				"${memcached_maxconn}" \
+				"${memcached_options}"
+		)"
+
 		timer_total="$(
 			awk \
 				-v timer_end="$(
 					date +%s.%N
 				)" \
-				-v timer_start="${TIMER_START}" \
+				-v timer_start="${timer_start}" \
 				'BEGIN { print \
 					timer_end - timer_start;
 				}'
@@ -150,6 +157,10 @@ function main ()
 			${timer_total}
 
 		EOT
+	else
+		options="$(
+			__get_options
+		)"
 	fi
 
 	exec ${nice} \


### PR DESCRIPTION
CLOSES #87

- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
- Updates Dockerfile with combined ADD to reduce layer count in final image.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
- Adds improvement to pull logic in systemd unit install template.
- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
- Adds improved `healtchcheck` and `memcached-wrapper` scripts.