### PR TITLE
Release changes for 1.3.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.env
+.env.example
 .git
 .gitignore
 dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .gitignore
 dist
 test
+docker-compose.yml
 LICENSE
 README-short.txt
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Memcached 1.4.
 
-### 1.3.1 - Unreleased
+### 1.3.1 - 2019-03-20
 
 - Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
 - Updates Dockerfile with combined ADD to reduce layer count in final image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CentOS-6 6.10 x86_64 - Memcached 1.4.
 - Adds improvement to pull logic in systemd unit install template.
 - Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
 - Adds improved `healtchcheck` and `memcached-wrapper` scripts.
+- Adds `docker-compose.yml` to `.dockerignore`.
 
 ### 1.3.0 - 2019-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Memcached 1.4.
 
+### 1.3.1 - Unreleased
+
+- Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
+- Updates Dockerfile with combined ADD to reduce layer count in final image.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
+- Adds improvement to pull logic in systemd unit install template.
+- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
+- Adds improved `healtchcheck` and `memcached-wrapper` scripts.
+
 ### 1.3.0 - 2019-02-12
 
 - Updates source image to [1.10.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdeathe/centos-ssh:1.10.0
+FROM jdeathe/centos-ssh:1.10.1
 
 ARG RELEASE_VERSION="1.3.0"
 
@@ -20,15 +20,11 @@ RUN rpm --rebuilddb \
 # ------------------------------------------------------------------------------
 # Copy files into place
 # ------------------------------------------------------------------------------
-ADD src/etc \
-	/etc/
-ADD src/opt/scmi \
-	/opt/scmi/
-ADD src/usr \
-	/usr/
+ADD src /
 
 # ------------------------------------------------------------------------------
 # Provisioning
+# - Replace placeholders with values in systemd service unit template
 # - Set permissions
 # ------------------------------------------------------------------------------
 RUN sed -i \
@@ -49,7 +45,8 @@ ENV MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER="true" \
 	MEMCACHED_MAXCONN="1024" \
 	MEMCACHED_OPTIONS="-U 0" \
 	SSH_AUTOSTART_SSHD="false" \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP="false"
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	SSH_AUTOSTART_SUPERVISOR_STDOUT="false"
 
 # ------------------------------------------------------------------------------
 # Set image metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jdeathe/centos-ssh:1.10.1
 
-ARG RELEASE_VERSION="1.3.0"
+ARG RELEASE_VERSION="1.3.1"
 
 # ------------------------------------------------------------------------------
 # Base install of required packages

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Docker Image including:
 
 ## Overview & links
 
-The latest CentOS-6 / CentOS-7 based releases can be pulled from the `centos-6` / `centos-7` Docker tags respectively. For production use it is recommended to select a specific release tag - the convention is `centos-6-1.3.0` OR `1.3.0` for the [1.3.0](https://github.com/jdeathe/centos-ssh-memcached/tree/1.3.0) release tag and `centos-7-2.2.0` OR `2.2.0` for the [2.2.0](https://github.com/jdeathe/centos-ssh/tree/2.2.0) release tag.
+The latest CentOS-6 / CentOS-7 based releases can be pulled from the `centos-6` / `centos-7` Docker tags respectively. For production use it is recommended to select a specific release tag - the convention is `centos-6-1.3.1` OR `1.3.1` for the [1.3.1](https://github.com/jdeathe/centos-ssh-memcached/tree/1.3.1) release tag and `centos-7-2.2.1` OR `2.2.1` for the [2.2.1](https://github.com/jdeathe/centos-ssh/tree/2.2.1) release tag.
 
 ### Tags and respective `Dockerfile` links
 
-- `centos-7`,`centos-7-2.2.0`,`2.2.0` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-7/Dockerfile)
-- `centos-6`,`centos-6-1.3.0`,`1.3.0` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-6/Dockerfile)
+- `centos-7`,`centos-7-2.2.1`,`2.2.1` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-7/Dockerfile)
+- `centos-6`,`centos-6-1.3.1`,`1.3.1` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-memcached/blob/centos-6/Dockerfile)
 
 Included in the build are the [SCL](https://www.softwarecollections.org/), [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout).
 
@@ -40,7 +40,7 @@ $ docker run -d \
   --name memcached.1 \
   -p 11211:11211/tcp \
   --sysctl "net.core.somaxconn=1024" \
-  jdeathe/centos-ssh-memcached:1.3.0
+  jdeathe/centos-ssh-memcached:1.3.1
 ```
 
 Now you can verify it is initialised and running successfully by inspecting the container's logs.
@@ -79,7 +79,7 @@ $ docker run \
   --sysctl "net.ipv4.ip_local_port_range=1024 65535" \
   --sysctl "net.ipv4.route.flush=1" \
   --env "MEMCACHED_CACHESIZE=32" \
-  jdeathe/centos-ssh-memcached:1.3.0
+  jdeathe/centos-ssh-memcached:1.3.1
 ```
 
 #### Environment Variables

--- a/src/etc/supervisord.d/memcached-wrapper.conf
+++ b/src/etc/supervisord.d/memcached-wrapper.conf
@@ -1,9 +1,9 @@
 [program:memcached-wrapper]
-priority = 100
-command = /usr/sbin/memcached-wrapper --verbose
-autostart = %(ENV_MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER)s
-startsecs = 0
 autorestart = true
+autostart = %(ENV_MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER)s
+command = /usr/sbin/memcached-wrapper --verbose
+priority = 100
 redirect_stderr = true
+startsecs = 0
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0

--- a/src/etc/systemd/system/centos-ssh-memcached.register@.service
+++ b/src/etc/systemd/system/centos-ssh-memcached.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -91,7 +92,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -104,7 +105,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -129,15 +130,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/11211 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/11211 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
       /usr/bin/etcdctl \
@@ -148,15 +149,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/udp/11211 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set\n'; \
         else \
-          echo update; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/udp/11211 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             11211 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \

--- a/src/etc/systemd/system/centos-ssh-memcached.register@.service
+++ b/src/etc/systemd/system/centos-ssh-memcached.register@.service
@@ -169,9 +169,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        echo set; \
+        printf -- 'set\n'; \
       else \
-        echo update; \
+        printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh-memcached@.service
+++ b/src/etc/systemd/system/centos-ssh-memcached@.service
@@ -26,7 +26,8 @@
 #     sudo systemctl enable -f {service-unit-instance-name}
 #
 # Start using:
-#     sudo systemctl [start|stop|restart|kill|status] {service-unit-instance-name}
+#     sudo systemctl [start|stop|restart|kill|status] \
+#       {service-unit-instance-name}
 #
 # Debugging:
 #     sudo systemctl status {service-unit-instance-name}
@@ -34,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -65,20 +67,12 @@ Environment="SYSCTL_NET_IPV4_ROUTE_FLUSH=1"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( \
-      if [[ -n $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ) ]]; \
-      then \
-        echo $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      else \
-        echo $(/usr/bin/docker images -q \
-          docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      fi; \
-    ) ]]; \
+  "if [[ -z \"$(/usr/bin/docker images -q \
+      ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]] \
+    && [[ -z \"$(/usr/bin/docker images -q \
+      docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]]; \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
@@ -140,7 +134,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_TCP_11211}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:11211/tcp' \
           $(\
@@ -173,7 +167,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_UDP_11211}\"; \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:11211/udp' \
           $(\

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -2,37 +2,40 @@
 
 set -e
 
-if ! ps axo command \
-	| grep -qE '^/usr/bin/python /usr/bin/supervisord'
-then
-	>&2 printf -- \
-		'%s\n' \
-		"supervisord not running."
-	exit 1
-fi
-
-if [[ ${MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER} == true ]]
-then
+function main ()
+{
 	if ! ps axo command \
-		| grep -qE '^/usr/bin/memcached '
+		| grep -qE '^/usr/bin/python /usr/bin/supervisord'
 	then
 		>&2 printf -- \
 			'%s\n' \
-			"memcached not running."
+			"supervisord not running."
 		exit 1
 	fi
 
-	if ! memcached-tool \
-			127.0.0.1:11211 \
-			stats \
-		| grep -qP \
-			'[ ]+accepting_conns[ ]+1[^0-9]*$'
+	if [[ ${MEMCACHED_AUTOSTART_MEMCACHED_WRAPPER} == true ]]
 	then
-		>&2 printf -- \
-			'%s\n' \
-			"memcached not accepting connections."
-		exit 1
-	fi
-fi
+		if ! ps axo command \
+			| grep -qE '^/usr/bin/memcached '
+		then
+			>&2 printf -- \
+				'%s\n' \
+				"memcached not running."
+			exit 1
+		fi
 
-exit 0
+		if ! memcached-tool \
+				127.0.0.1:11211 \
+				stats \
+			| grep -qP \
+				'[ ]+accepting_conns[ ]+1[^0-9]*$'
+		then
+			>&2 printf -- \
+				'%s\n' \
+				"memcached not accepting connections."
+			exit 1
+		fi
+	fi
+}
+
+main "${@}"

--- a/src/usr/sbin/memcached-wrapper
+++ b/src/usr/sbin/memcached-wrapper
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-readonly TIMER_START="$(
-	date +%s.%N
-)"
+set -e
 
 function __is_valid_memcached_cachesize ()
 {
@@ -92,24 +90,16 @@ function __get_options ()
 function main ()
 {
 	local -r bin="/usr/bin/memcached"
-	local -r memcached_cachesize="$(
-		__get_memcached_cachesize
-	)"
-	local -r memcached_maxconn="$(
-		__get_memcached_maxconn
-	)"
-	local -r memcached_options="$(
-		__get_memcached_options
-	)"
 	local -r nice="/bin/nice"
 	local -r niceness="0"
-	local -r options="$(
-		__get_options \
-			"${memcached_cachesize}" \
-			"${memcached_maxconn}" \
-			"${memcached_options}"
+	local -r timer_start="$(
+		date +%s.%N
 	)"
 
+	local memcached_cachesize
+	local memcached_maxconn
+	local memcached_options
+	local options
 	local timer_total
 	local verbose=false
 
@@ -126,12 +116,29 @@ function main ()
 
 	if [[ ${verbose} == true ]]
 	then
+		memcached_cachesize="$(
+			__get_memcached_cachesize
+		)"
+		memcached_maxconn="$(
+			__get_memcached_maxconn
+		)"
+		memcached_options="$(
+			__get_memcached_options
+		)"
+
+		options="$(
+			__get_options \
+				"${memcached_cachesize}" \
+				"${memcached_maxconn}" \
+				"${memcached_options}"
+		)"
+
 		timer_total="$(
 			awk \
 				-v timer_end="$(
 					date +%s.%N
 				)" \
-				-v timer_start="${TIMER_START}" \
+				-v timer_start="${timer_start}" \
 				'BEGIN { print \
 					timer_end - timer_start;
 				}'
@@ -150,6 +157,10 @@ function main ()
 			${timer_total}
 
 		EOT
+	else
+		options="$(
+			__get_options
+		)"
 	fi
 
 	exec ${nice} \


### PR DESCRIPTION
- Updates source image to [1.10.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.10.1).
- Updates Dockerfile with combined ADD to reduce layer count in final image.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
- Adds improvement to pull logic in systemd unit install template.
- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
- Adds improved `healtchcheck` and `memcached-wrapper` scripts.
- Adds `docker-compose.yml` to `.dockerignore`.